### PR TITLE
fix: falsy values not being properly compared

### DIFF
--- a/src/nitpick/blender.py
+++ b/src/nitpick/blender.py
@@ -11,6 +11,7 @@ import abc
 import json
 import re
 import shlex
+from collections.abc import Iterable
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
@@ -165,7 +166,7 @@ class ListDetail:  # pylint: disable=too-few-public-methods
 
 def set_key_if_not_empty(dict_: JsonDict, key: str, value: Any) -> None:
     """Update the dict if the value is valid."""
-    if not value:
+    if isinstance(value, Iterable) and not value:
         return
     dict_[key] = value
 

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -496,3 +496,31 @@ def test_generic_ini_with_missing_header(tmp_path):
     ).assert_file_contents(
         "generic.ini", expected_generic_ini
     )
+
+
+def test_falsy_values_should_be_reported_and_fixed(tmp_path, datadir):
+    """Test that falsy and truthy values are included in the report."""
+    filename = "foo/file.ini"
+    project = ProjectMock(tmp_path).save_file(filename, datadir / "falsy_values/actual.ini")
+    project.style(datadir / "falsy_values/desired.toml").api_check_then_fix(
+        *[
+            Fuss(
+                True,
+                filename,
+                Violations.OPTION_HAS_DIFFERENT_VALUE.code,
+                f": [config]{name} is {actual} but it should be like this:",
+                f"[config]\n{name} = {expected}",
+            )
+            for (name, actual, expected) in [
+                ("boolean_true_unmatch", "false", "True"),
+                ("boolean_false_unmatch", "true", "False"),
+                ("string_a_unmatch", "string_b", "string_a"),
+                ("string_b_unmatch", "string_a", "string_b"),
+                ("truthy_int_unmatch", "0", "1"),
+                ("falsy_int_unmatch", "1", "0"),
+                ("truthy_float_unmatch", "0.0", "1.0"),
+                ("falsy_float_unmatch", "1.0", "0.0"),
+            ]
+        ]
+    ).assert_file_contents(filename, datadir / "falsy_values/expected.ini")
+    project.api_check().assert_violations()

--- a/tests/test_ini/falsy_values/actual.ini
+++ b/tests/test_ini/falsy_values/actual.ini
@@ -1,0 +1,17 @@
+[config]
+boolean_true_match = true
+boolean_true_unmatch = false
+boolean_false_match = false
+boolean_false_unmatch = true
+string_a_match = string_a
+string_a_unmatch = string_b
+string_b_match = string_b
+string_b_unmatch = string_a
+truthy_int_match = 1
+truthy_int_unmatch = 0
+falsy_int_match = 0
+falsy_int_unmatch = 1
+truthy_float_match = 1.0
+truthy_float_unmatch = 0.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 1.0

--- a/tests/test_ini/falsy_values/desired.toml
+++ b/tests/test_ini/falsy_values/desired.toml
@@ -1,0 +1,20 @@
+["foo/file.ini".config]
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+
+string_a_match = "string_a"
+string_a_unmatch = "string_a"
+string_b_match = "string_b"
+string_b_unmatch = "string_b"
+
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_ini/falsy_values/expected.ini
+++ b/tests/test_ini/falsy_values/expected.ini
@@ -1,0 +1,17 @@
+[config]
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+string_a_match = string_a
+string_a_unmatch = string_a
+string_b_match = string_b
+string_b_unmatch = string_b
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -165,3 +165,28 @@ def test_missing_different_values_any_toml(tmp_path):
         list = ["a", "b", "c"]
         """,
     )
+
+
+def test_falsy_values_should_be_reported_and_fixed(tmp_path, datadir):
+    """Test that falsy and truthy values are included in the report."""
+    filename = "foo/file.toml"
+    project = ProjectMock(tmp_path).save_file(filename, datadir / "falsy_values/actual.toml")
+    project.style(datadir / "falsy_values/desired.toml").api_check_then_fix(
+        Fuss(
+            True,
+            filename,
+            319,
+            " has different values. Use this:",
+            """
+            boolean_true_unmatch = true
+            boolean_false_unmatch = false
+            string_a_unmatch = "string_a"
+            string_b_unmatch = "string_b"
+            truthy_int_unmatch = 1
+            falsy_int_unmatch = 0
+            truthy_float_unmatch = 1.0
+            falsy_float_unmatch = 0.0
+            """,
+        )
+    ).assert_file_contents(filename, datadir / "falsy_values/expected.toml")
+    project.api_check().assert_violations()

--- a/tests/test_toml/falsy_values/actual.toml
+++ b/tests/test_toml/falsy_values/actual.toml
@@ -1,0 +1,16 @@
+boolean_true_match = true
+boolean_true_unmatch = false
+boolean_false_match = false
+boolean_false_unmatch = true
+string_a_match = "string_a"
+string_a_unmatch = "string_b"
+string_b_match = "string_b"
+string_b_unmatch = "string_a"
+truthy_int_match = 1
+truthy_int_unmatch = 0
+falsy_int_match = 0
+falsy_int_unmatch = 1
+truthy_float_match = 1.0
+truthy_float_unmatch = 0.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 1.0

--- a/tests/test_toml/falsy_values/desired.toml
+++ b/tests/test_toml/falsy_values/desired.toml
@@ -1,0 +1,20 @@
+["foo/file.toml"]
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+
+string_a_match = "string_a"
+string_a_unmatch = "string_a"
+string_b_match = "string_b"
+string_b_unmatch = "string_b"
+
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_toml/falsy_values/expected.toml
+++ b/tests/test_toml/falsy_values/expected.toml
@@ -1,0 +1,16 @@
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+string_a_match = "string_a"
+string_a_unmatch = "string_a"
+string_b_match = "string_b"
+string_b_unmatch = "string_b"
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -156,3 +156,28 @@ def test_maximum_two_level_nesting_on_lists_using_jmes_expression_as_list_key_fa
         ),
     ).assert_file_contents(filename, datadir / "jmes-list-key-expected.yaml")
     project.api_check().assert_violations()
+
+
+def test_falsy_values_should_be_reported_and_fixed(tmp_path, datadir):
+    """Test that falsy and truthy values are included in the report."""
+    filename = "foo/file.yaml"
+    project = ProjectMock(tmp_path).save_file(filename, datadir / "falsy_values/actual.yaml")
+    project.style(datadir / "falsy_values/desired.toml").api_check_then_fix(
+        Fuss(
+            True,
+            filename,
+            369,
+            " has different values. Use this:",
+            """
+            boolean_true_unmatch: true
+            boolean_false_unmatch: false
+            string_a_unmatch: string_a
+            string_b_unmatch: string_b
+            truthy_int_unmatch: 1
+            falsy_int_unmatch: 0
+            truthy_float_unmatch: 1.0
+            falsy_float_unmatch: 0.0
+            """,
+        )
+    ).assert_file_contents(filename, datadir / "falsy_values/expected.yaml")
+    project.api_check().assert_violations()

--- a/tests/test_yaml/falsy_values/actual.yaml
+++ b/tests/test_yaml/falsy_values/actual.yaml
@@ -1,0 +1,16 @@
+boolean_true_match: true
+boolean_true_unmatch: false
+boolean_false_match: false
+boolean_false_unmatch: true
+string_a_match: "string_a"
+string_a_unmatch: "string_b"
+string_b_match: "string_b"
+string_b_unmatch: "string_a"
+truthy_int_match: 1
+truthy_int_unmatch: 0
+falsy_int_match: 0
+falsy_int_unmatch: 1
+truthy_float_match: 1.0
+truthy_float_unmatch: 0.0
+falsy_float_match: 0.0
+falsy_float_unmatch: 1.0

--- a/tests/test_yaml/falsy_values/desired.toml
+++ b/tests/test_yaml/falsy_values/desired.toml
@@ -1,0 +1,20 @@
+["foo/file.yaml"]
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+
+string_a_match = "string_a"
+string_a_unmatch = "string_a"
+string_b_match = "string_b"
+string_b_unmatch = "string_b"
+
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_yaml/falsy_values/expected.yaml
+++ b/tests/test_yaml/falsy_values/expected.yaml
@@ -1,0 +1,16 @@
+boolean_true_match: true
+boolean_true_unmatch: true
+boolean_false_match: false
+boolean_false_unmatch: false
+string_a_match: "string_a"
+string_a_unmatch: "string_a"
+string_b_match: "string_b"
+string_b_unmatch: "string_b"
+truthy_int_match: 1
+truthy_int_unmatch: 1
+falsy_int_match: 0
+falsy_int_unmatch: 0
+truthy_float_match: 1.0
+truthy_float_unmatch: 1.0
+falsy_float_match: 0.0
+falsy_float_unmatch: 0.0


### PR DESCRIPTION
Issues fixed by this pull request:

- Fix https://github.com/andreoliwa/nitpick/issues/489

## Proposed changes

1. Check that the value is iterable to skip if falsy.

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [ ] ~CLI~
  - [ ] ~`flake8` plugin (normal mode)~
  - [ ] ~`flake8` plugin (offline mode)~
- [ ] ~Write documentation when there's a new API or functionality~

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the comparison logic for falsy values in `set_key_if_not_empty` function and add comprehensive tests for falsy and truthy value handling in configuration files.

### Why are these changes being made?

The previous implementation incorrectly compared falsy values, leading to unexpected behavior when updating dictionaries. By ensuring that only iterable values are checked for emptiness, the logic is corrected. Extensive tests across multiple file formats (INI, TOML, YAML) ensure that the system reliably reports and fixes mismatches between actual and expected values, improving the robustness and correctness of configuration management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->