### PR TITLE
fix: Multiple conflicting plugins working on the same file

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -21,7 +21,7 @@ enabled = true
 name = "python"
 
 [analyzers.meta]
-runtime_version = "3.x.x"
+runtime_version = "3.x"
 
 [[transformers]]
 enabled = true

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -21,7 +21,7 @@ enabled = true
 name = "python"
 
 [analyzers.meta]
-runtime_version = "3.x"
+runtime_version = "3.x.x"
 
 [[transformers]]
 enabled = true

--- a/src/nitpick/plugins/__init__.py
+++ b/src/nitpick/plugins/__init__.py
@@ -13,15 +13,15 @@ from typing import TYPE_CHECKING
 import pluggy
 
 from nitpick.constants import PROJECT_NAME
+from nitpick.plugins.info import FileInfo
 
 if TYPE_CHECKING:
     from nitpick.plugins.base import NitpickPlugin
-    from nitpick.plugins.info import FileInfo
 
 hookspec = pluggy.HookspecMarker(PROJECT_NAME)
 hookimpl = pluggy.HookimplMarker(PROJECT_NAME)
 
-__all__ = ("hookimpl", "hookspec")
+__all__ = ("FileInfo", "hookimpl", "hookspec")
 
 
 @hookspec

--- a/src/nitpick/plugins/info.py
+++ b/src/nitpick/plugins/info.py
@@ -42,8 +42,7 @@ class FileInfo:
         conflicting_tags = {"ini", "toml", "yaml", "json"}
         found_tags = conflicting_tags.intersection(tags)
         if len(found_tags) > 1:
-            ext = Path(path).suffix
-            if ext:
+            if ext := Path(path).suffix:
                 # The file has a valid extension and not just some ".dotfile"
                 ext = ext[1:].lower()
                 if ext in found_tags:

--- a/src/nitpick/plugins/info.py
+++ b/src/nitpick/plugins/info.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from identify import identify
@@ -29,5 +30,26 @@ class FileInfo:
             clean_path = DOT + path_from_root
         else:
             clean_path = DOT + path_from_root[1:] if path_from_root.startswith("-") else path_from_root
-        tags = set(identify.tags_from_filename(clean_path))
+        tags = FileInfo.tags_from_filename(clean_path)
         return cls(project, clean_path, tags)
+
+    @staticmethod
+    def tags_from_filename(path: str) -> set[str]:
+        """Get a list of tags associated with the file."""
+        tags = identify.tags_from_filename(path)
+
+        # Check for conflicting tags, there can be only one of these
+        conflicting_tags = {"ini", "toml", "yaml", "json"}
+        found_tags = conflicting_tags.intersection(tags)
+        if len(found_tags) > 1:
+            ext = Path(path).suffix
+            if ext:
+                # The file has a valid extension and not just some ".dotfile"
+                ext = ext[1:].lower()
+                if ext in found_tags:
+                    # Keep only the tag that matches the extension
+                    tags -= found_tags
+                    tags.add(ext)
+
+        # If there's no conflict or the extension is not recognized, return all the tags
+        return tags

--- a/src/nitpick/plugins/info.py
+++ b/src/nitpick/plugins/info.py
@@ -7,9 +7,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from identify import identify
+from loguru import logger
 
 from nitpick.constants import DOT
 from nitpick.exceptions import Deprecation
+
+CONFLICTING_TAGS = {"ini", "toml", "yaml", "json"}
 
 if TYPE_CHECKING:
     from nitpick.core import Project
@@ -38,17 +41,17 @@ class FileInfo:
         """Get a list of tags associated with the file."""
         tags = identify.tags_from_filename(path)
 
-        # Check for conflicting tags, there can be only one of these
-        conflicting_tags = {"ini", "toml", "yaml", "json"}
-        found_tags = conflicting_tags.intersection(tags)
-        if len(found_tags) > 1:
-            if ext := Path(path).suffix:
-                # The file has a valid extension and not just some ".dotfile"
-                ext = ext[1:].lower()
-                if ext in found_tags:
-                    # Keep only the tag that matches the extension
-                    tags -= found_tags
-                    tags.add(ext)
+        # Check for conflicting tags, there can be only one of them
+        found_tags = CONFLICTING_TAGS.intersection(tags)
+        if len(found_tags) > 1 and (ext := Path(path).suffix):
+            # The file has a valid extension and not just some ".dotfile"
+            ext = ext[1:].lower()
+            logger.info(f"Found conflicting tags {found_tags} for file at {path}")
+            if ext in found_tags:
+                logger.info(f"Keeping '{ext}' tag as it matches the extension")
+                # Keep only the tag that matches the extension
+                tags -= found_tags
+                tags.add(ext)
 
         # If there's no conflict or the extension is not recognized, return all the tags
         return tags

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -13,14 +13,11 @@ import pytest
 from furl import furl
 from testfixtures import compare
 
-from nitpick.constants import EDITOR_CONFIG, GIT_DIR, GIT_IGNORE, PYTHON_TOX_INI
-from nitpick.generic import (
-    _url_to_posix_path,
-    _url_to_windows_path,
-    get_global_gitignore_path,
-    glob_non_ignored_files,
-    relative_to_current_dir,
-)
+from nitpick.constants import (EDITOR_CONFIG, GIT_DIR, GIT_IGNORE,
+                               PYTHON_TOX_INI)
+from nitpick.generic import (_url_to_posix_path, _url_to_windows_path,
+                             get_global_gitignore_path, glob_non_ignored_files,
+                             relative_to_current_dir)
 from nitpick.plugins import FileInfo
 
 
@@ -74,14 +71,7 @@ def test_relative_to_current_dir(home, cwd):
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows-only test")
-@pytest.mark.parametrize(
-    "test_path",
-    [
-        "C:\\",
-        r"C:\path\file.toml",
-        r"//server/share/path/file.toml",
-    ],
-)
+@pytest.mark.parametrize("test_path", ["C:\\", r"C:\path\file.toml", r"//server/share/path/file.toml"])
 def test_url_to_windows_path(test_path):
     """Verify that Path to URL to Path conversion preserves the path."""
     path = WindowsPath(test_path)
@@ -90,14 +80,7 @@ def test_url_to_windows_path(test_path):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX-only test")
-@pytest.mark.parametrize(
-    "test_path",
-    [
-        "/",
-        "/path/to/file.toml",
-        "//double/slash/path.toml",
-    ],
-)
+@pytest.mark.parametrize("test_path", ["/", "/path/to/file.toml", "//double/slash/path.toml"])
 def test_url_to_posix_path(test_path):
     """Verify that Path to URL to Path conversion preserves the path."""
     path = PosixPath(test_path)
@@ -139,13 +122,9 @@ def test_glob_local_gitignore(some_directory: Path) -> None:
         some_directory / "README.md",
         some_directory / "src" / "module.py",
     }
-    assert set(glob_non_ignored_files(some_directory, "*.md")) == {
-        some_directory / "README.md",
-    }
+    assert set(glob_non_ignored_files(some_directory, "*.md")) == {some_directory / "README.md"}
     assert set(glob_non_ignored_files(some_directory, "*.txt")) == set()
-    assert set(glob_non_ignored_files(some_directory, "**/*.py")) == {
-        some_directory / "src" / "module.py",
-    }
+    assert set(glob_non_ignored_files(some_directory, "**/*.py")) == {some_directory / "src" / "module.py"}
 
 
 @pytest.mark.parametrize("some_directory", ["no_git_dir"], indirect=True)
@@ -178,12 +157,7 @@ def test_glob_global_gitignore(some_directory: Path) -> None:
     ],
 )
 @mock.patch("subprocess.check_output")
-def test_error_when_calling_git_config(
-    mock_check_output,
-    capsys,
-    exception: Exception,
-    message: str,
-) -> None:
+def test_error_when_calling_git_config(mock_check_output, capsys, exception: Exception, message: str) -> None:
     """Test error when calling git config."""
     mock_check_output.side_effect = exception
     assert get_global_gitignore_path() is None
@@ -194,22 +168,10 @@ def test_error_when_calling_git_config(
 @pytest.mark.parametrize(
     ("filepath", "expected_tags"),
     [
-        (
-            "foo/.pylintrc.toml",
-            {"pylintrc", "text", "toml"},
-        ),
-        (
-            "foo/pylintrc.toml",
-            {"pylintrc", "text", "toml"},
-        ),
-        (
-            "foo/.pylintrc",
-            {"pylintrc", "text", "ini"},
-        ),
-        (
-            "foo/pylintrc",
-            {"pylintrc", "text", "ini"},
-        ),
+        ("foo/.pylintrc.toml", {"pylintrc", "text", "toml"}),
+        ("foo/pylintrc.toml", {"pylintrc", "text", "toml"}),
+        ("foo/.pylintrc", {"pylintrc", "text", "ini"}),
+        ("foo/pylintrc", {"pylintrc", "text", "ini"}),
     ],
 )
 def test_different_types_of_pylintrc_config_should_work(filepath: str, expected_tags: set[str]):

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -21,6 +21,7 @@ from nitpick.generic import (
     glob_non_ignored_files,
     relative_to_current_dir,
 )
+from nitpick.plugins import FileInfo
 
 
 @mock.patch.object(Path, "cwd")
@@ -188,3 +189,37 @@ def test_error_when_calling_git_config(
     assert get_global_gitignore_path() is None
     captured = capsys.readouterr()
     assert captured.err.strip().casefold() == message.strip().casefold()
+
+
+@pytest.mark.parametrize(
+    ("filepath", "expected_tags"),
+    [
+        (
+            "foo/.pylintrc.toml",
+            {"pylintrc", "text", "toml"},
+        ),
+        (
+            "foo/pylintrc.toml",
+            {"pylintrc", "text", "toml"},
+        ),
+        (
+            "foo/.pylintrc",
+            {"pylintrc", "text", "ini"},
+        ),
+        (
+            "foo/pylintrc",
+            {"pylintrc", "text", "ini"},
+        ),
+    ],
+)
+def test_different_types_of_pylintrc_config_should_work(filepath: str, expected_tags: set[str]):
+    """Different pylintrc configs should have different expected tags.
+
+    'pylintrc' is a special case where the config can either be a TOML or INI file.
+    Determining the correct tags is important for the plugins to work correctly.
+    Having an incorrect plugin working on a file can lead to unexpected results.
+
+    More on how pylint search for and use configuration files:
+    https://pylint.pycqa.org/en/latest/user_guide/usage/run.html#command-line-options
+    """
+    assert FileInfo.tags_from_filename(filepath) == expected_tags

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -13,11 +13,14 @@ import pytest
 from furl import furl
 from testfixtures import compare
 
-from nitpick.constants import (EDITOR_CONFIG, GIT_DIR, GIT_IGNORE,
-                               PYTHON_TOX_INI)
-from nitpick.generic import (_url_to_posix_path, _url_to_windows_path,
-                             get_global_gitignore_path, glob_non_ignored_files,
-                             relative_to_current_dir)
+from nitpick.constants import EDITOR_CONFIG, GIT_DIR, GIT_IGNORE, PYTHON_TOX_INI
+from nitpick.generic import (
+    _url_to_posix_path,
+    _url_to_windows_path,
+    get_global_gitignore_path,
+    glob_non_ignored_files,
+    relative_to_current_dir,
+)
 from nitpick.plugins import FileInfo
 
 


### PR DESCRIPTION
Issues fixed by this pull request:

- Fix #6 

## Proposed changes

1. Avoid conflicting tags for a file, thus avoiding having multiple conflicting nitpick plugins working on it

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [ ] ~CLI~
  - [ ] ~`flake8` plugin (normal mode)~
  - [ ] ~`flake8` plugin (offline mode)~
- [ ] ~Write documentation when there's a new API or functionality~

## Summary by Sourcery

Bug Fixes:
- Fix an issue where multiple plugins could conflict when applied to the same file.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Resolve conflicts between multiple plugins by ensuring only one valid plugin tag, based on file extension, is associated with each file.

### Why are these changes being made?

Conflicting plugin tags from files with multiple potential tags caused incorrect plugins to operate on files, leading to unexpected results. This approach leverages file extensions to accurately assign a single plugin tag, ensuring correct plugin functionality and handling edge cases such as special `.pylintrc` configurations. The addition of relevant tests ensures the reliability of these changes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tag processing for configuration files with the addition of a method to retrieve tags based on filename.
	- Improved handling of file extensions and conflict resolution for tags.
	- `FileInfo` is now part of the public API.
	- New configuration files introduced for code analysis and linting tools.
	- New rules added for YAML linting to enforce stricter syntax validation.

- **Tests**
	- Added test coverage for different types of `.pylintrc` configuration files.

- **Chores**
	- Updated Python runtime version specification for analysis.
	- New entries added to `.gitignore` to streamline version control.
	- Enhanced linting configuration for various file types.
	- Configuration updates for multiple analysis tools to improve code quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->