### PR TITLE
chore: Update README installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -338,36 +338,27 @@ Quickstart
 Install
 ~~~~~~~
 
+We plan to port our fixes/enhancements from ``develop-ng`` branch to upstream at a later time. Until then, you need to install our version of ``nitpick`` directly from the GitHub repository:
+
 Install in an isolated global environment with
 `pipx <https://github.com/pipxproject/pipx>`_::
 
-    # Latest PyPI release
-    pipx install nitpick
-
     # Development branch from GitHub
-    pipx install git+https://github.com/andreoliwa/nitpick
+    pipx install git+https://github.com/NextGenContributions/nitpick
 
-On macOS/Linux, install with
-`Homebrew <https://github.com/Homebrew/brew>`_::
-
-    # Latest PyPI release
-    brew install andreoliwa/formulae/nitpick
-
-    # Development branch from GitHub
-    brew install andreoliwa/formulae/nitpick --HEAD
-
-On Arch Linux, install with yay::
-
-    yay -Syu nitpick
-
-Add to your project with
+Or add to your project with
 `Poetry <https://github.com/python-poetry/poetry>`_::
 
-    poetry add --dev nitpick
+    poetry add --dev git+https://github.com/NextGenContributions/nitpick
+
+Or add to your project with
+`uv <https://github.com/astral-sh/uv>`_::
+
+    uv add --dev git+https://github.com/NextGenContributions/nitpick
 
 Or install it with pip::
 
-    pip install -U nitpick
+    pip install -U git+https://github.com/NextGenContributions/nitpick
 
 Run
 ~~~


### PR DESCRIPTION
Issues fixed by this pull request:

- Fix #13

## Proposed changes

1. Update `Install` section

## Summary by Sourcery

Documentation:
- Update the Install section of the README.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the installation instructions in the README to specify installing the development version of `nitpick` directly from the `NextGenContributions` GitHub repository using `pipx`, `Poetry`, `uv`, or `pip`.

### Why are these changes being made?

The installation instructions are updated to reflect the current state where the fixes/enhancements are in the `develop-ng` branch, and will be ported later to the upstream. This eliminates confusion and ensures users install the correct version until then. Furthermore, redundant instructions for installing via Homebrew and Arch Linux have been removed for simplification and consistency with the recommended tools.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with new installation instructions for `nitpick` tool
	- Added note about installing from NextGenContributions GitHub repository
	- Removed previous PyPI installation commands
	- Included information about future planned fixes and enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->