### PR TITLE
fix: Handling of TOML section with quoted name

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,45 @@
+---
+engines:
+  bandit: # Python security analyzer
+    enabled: true
+  hadolint: # Docker linter
+    enabled: true
+  prospector: # Python static analysis tool
+    enabled: true
+  pylintpython3: # Python linter
+    enabled: true
+  jacksonlinter: # JSON linter
+    enabled: true
+  markdownlint: # Markdown linter
+    enabled: true
+  semgrep: # Generic static analysis tool
+    enabled: true
+  shellcheck: # Shell script linter
+    enabled: true
+  spectral: # JSON/YAML linter
+    enabled: true
+  duplication: # Duplicated code detection
+    minTokenMatch: 50
+    skipLexicalErrors: true
+    ignoreLiterals: true
+    ignoreIdentifiers: true
+    ignoreAnnotations: true
+    ignoreUsings: true
+    exclude_paths:
+      - test_*.py
+      - tests/**
+
+exclude_paths:
+  - "*.egg"
+  - "*.egg-info/**"
+  - .eggs/**
+  - .git/**
+  - .tox/**
+  - .venv/**
+  - __pycache__/**
+  - bin/**
+  - build/**
+  - dist/**
+  # Test files
+  - test_*.py
+  - tests/**

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,32 @@
+exclude_patterns = [
+  "*.egg",
+  "*.egg-info/**",
+  ".eggs/**",
+  ".git/**",
+  ".tox/**",
+  ".venv/**",
+  "__pycache__/**",
+  "bin/**",
+  "build/**",
+  "dist/**",
+]
+test_patterns = [
+  "test_*.py",
+  "tests/**",
+]
+version = 1
+
+[[analyzers]]
+enabled = true
+name = "python"
+
+[analyzers.meta]
+runtime_version = "3.x"
+
+[[transformers]]
+enabled = true
+name = "ruff"
+
+[[transformers]]
+enabled = true
+name = "isort"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -21,12 +21,12 @@ enabled = true
 name = "python"
 
 [analyzers.meta]
-runtime_version = "3.x"
+cyclomatic_complexity_threshold = "medium"
+max_line_length = 120 # should match this repo's config in e.g. pyproject.toml
+runtime_version = "3.x.x"
+skip_doc_coverage = ["init", "magic", "module"]
+type_checker = "mypy"
 
 [[transformers]]
 enabled = true
 name = "ruff"
-
-[[transformers]]
-enabled = true
-name = "isort"

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,9 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,0 +1,2 @@
+# Prettier friendly markdownlint config (all formatting rules disabled)
+extends: markdownlint/style/prettier

--- a/.trunk/configs/.shellcheckrc
+++ b/.trunk/configs/.shellcheckrc
@@ -1,0 +1,7 @@
+enable=all
+source-path=SCRIPTDIR
+disable=SC2154
+
+# If you're having issues with shellcheck following source, disable the errors via:
+# disable=SC1090
+# disable=SC1091

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,7 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,49 @@
+# This file controls the behavior of Trunk: https://docs.trunk.io/cli
+# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
+version: 0.1
+cli:
+  version: 1.22.9
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.6.7
+      uri: https://github.com/trunk-io/plugins
+# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
+runtimes:
+  enabled:
+    - python@>=3.10.8
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+lint:
+  enabled:
+    - actionlint@1.7.7
+    - bandit@1.8.2
+    - git-diff-check
+    - markdownlint@0.44.0
+    - mypy@1.14.1
+    - osv-scanner@1.9.2
+    - prettier@3.4.2
+    - pylint@3.3.4
+    - renovate@39.141.0
+    - ruff@0.9.3
+    - shellcheck@0.10.0
+    - shfmt@3.6.0
+    - taplo@0.9.3
+    - trufflehog@3.88.3
+    - yamllint@1.35.1
+  ignore:
+    - linters: [ALL]
+      paths:
+        - "*.egg"
+        - "*.egg-info/**"
+        - .eggs/**
+        - .git/**
+        - .tox/**
+        - .venv/**
+        - __pycache__/**
+        - bin/**
+        - build/**
+        - dist/**
+        # Test files
+        - test_*.py
+        - tests/**

--- a/README.rst
+++ b/README.rst
@@ -338,36 +338,27 @@ Quickstart
 Install
 ~~~~~~~
 
+We plan to port our fixes/enhancements from ``develop-ng`` branch to upstream at a later time. Until then, you need to install our version of ``nitpick`` directly from the GitHub repository:
+
 Install in an isolated global environment with
 `pipx <https://github.com/pipxproject/pipx>`_::
 
-    # Latest PyPI release
-    pipx install nitpick
-
     # Development branch from GitHub
-    pipx install git+https://github.com/andreoliwa/nitpick
+    pipx install git+https://github.com/NextGenContributions/nitpick
 
-On macOS/Linux, install with
-`Homebrew <https://github.com/Homebrew/brew>`_::
-
-    # Latest PyPI release
-    brew install andreoliwa/formulae/nitpick
-
-    # Development branch from GitHub
-    brew install andreoliwa/formulae/nitpick --HEAD
-
-On Arch Linux, install with yay::
-
-    yay -Syu nitpick
-
-Add to your project with
+Or add to your project with
 `Poetry <https://github.com/python-poetry/poetry>`_::
 
-    poetry add --dev nitpick
+    poetry add --dev git+https://github.com/NextGenContributions/nitpick
+
+Or add to your project with
+`uv <https://github.com/astral-sh/uv>`_::
+
+    uv add --dev git+https://github.com/NextGenContributions/nitpick
 
 Or install it with pip::
 
-    pip install -U nitpick
+    pip install -U git+https://github.com/NextGenContributions/nitpick
 
 Run
 ~~~

--- a/docs/nitpick_section.rst
+++ b/docs/nitpick_section.rst
@@ -50,15 +50,15 @@ The message is optional.
 Comma separated values
 ^^^^^^^^^^^^^^^^^^^^^^
 
-On ``setup.cfg``, some keys are lists of multiple values separated by commas, like ``flake8.ignore``.
+On ``setup.cfg`` or ``.flake8``, some keys are lists of multiple values separated by commas, like ``flake8.ignore``.
 
 On the style file, it's possible to indicate which key/value pairs should be treated as multiple values instead of an exact string.
 Multiple keys can be added.
 
 .. code-block:: toml
 
-    [nitpick.files."setup.cfg"]
-    comma_separated_values = ["flake8.ignore", "isort.some_key", "another_section.another_key"]
+    [nitpick.files.comma_separated_values]
+    "setup.cfg" = ["flake8.ignore", "isort.some_key", "another_section.another_key"]
 
 [nitpick.styles]
 ----------------

--- a/src/nitpick/blender.py
+++ b/src/nitpick/blender.py
@@ -11,6 +11,7 @@ import abc
 import json
 import re
 import shlex
+from collections.abc import Iterable
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
@@ -165,7 +166,7 @@ class ListDetail:  # pylint: disable=too-few-public-methods
 
 def set_key_if_not_empty(dict_: JsonDict, key: str, value: Any) -> None:
     """Update the dict if the value is valid."""
-    if not value:
+    if isinstance(value, Iterable) and not value:
         return
     dict_[key] = value
 

--- a/src/nitpick/plugins/__init__.py
+++ b/src/nitpick/plugins/__init__.py
@@ -13,15 +13,15 @@ from typing import TYPE_CHECKING
 import pluggy
 
 from nitpick.constants import PROJECT_NAME
+from nitpick.plugins.info import FileInfo
 
 if TYPE_CHECKING:
     from nitpick.plugins.base import NitpickPlugin
-    from nitpick.plugins.info import FileInfo
 
 hookspec = pluggy.HookspecMarker(PROJECT_NAME)
 hookimpl = pluggy.HookimplMarker(PROJECT_NAME)
 
-__all__ = ("hookimpl", "hookspec")
+__all__ = ("FileInfo", "hookimpl", "hookspec")
 
 
 @hookspec

--- a/src/nitpick/plugins/base.py
+++ b/src/nitpick/plugins/base.py
@@ -9,10 +9,9 @@ from typing import TYPE_CHECKING, ClassVar, Iterator
 from autorepr import autotext
 from loguru import logger
 
-from nitpick.blender import BaseDoc, flatten_quotes, search_json
+from nitpick.blender import BaseDoc, flatten_quotes
 from nitpick.config import SpecialConfig
 from nitpick.constants import CONFIG_DUNDER_LIST_KEYS
-from nitpick.typedefs import JsonDict, mypy_property
 from nitpick.violations import Fuss, Reporter, SharedViolations
 
 if TYPE_CHECKING:
@@ -21,6 +20,7 @@ if TYPE_CHECKING:
     from marshmallow import Schema
 
     from nitpick.plugins.info import FileInfo
+    from nitpick.typedefs import JsonDict
 
 
 class NitpickPlugin(metaclass=abc.ABCMeta):  # pylint: disable=too-many-instance-attributes
@@ -89,23 +89,11 @@ class NitpickPlugin(metaclass=abc.ABCMeta):  # pylint: disable=too-many-instance
         """
         return SpecialConfig()
 
-    @mypy_property
-    def nitpick_file_dict(self) -> JsonDict:
-        """Nitpick configuration for this file as a TOML dict, taken from the style file."""
-        return search_json(self.info.project.nitpick_section, f'files."{self.filename}"', {})
-
     def entry_point(self) -> Iterator[Fuss]:
         """Entry point of the Nitpick plugin."""
         self.post_init()
 
-        should_exist: bool = bool(self.info.project.nitpick_files_section.get(self.filename, True))
-        if self.file_path.exists() and not should_exist:
-            logger.info(f"{self}: File {self.filename} exists when it should not")
-            # Only display this message if the style is valid.
-            yield self.reporter.make_fuss(SharedViolations.DELETE_FILE)
-            return
-
-        has_config_dict = bool(self.expected_config or self.nitpick_file_dict)
+        has_config_dict = bool(self.expected_config)
         if not has_config_dict:
             return
 

--- a/src/nitpick/plugins/info.py
+++ b/src/nitpick/plugins/info.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from identify import identify
+from loguru import logger
 
 from nitpick.constants import DOT
 from nitpick.exceptions import Deprecation
+
+CONFLICTING_TAGS = {"ini", "toml", "yaml", "json"}
 
 if TYPE_CHECKING:
     from nitpick.core import Project
@@ -29,5 +33,25 @@ class FileInfo:
             clean_path = DOT + path_from_root
         else:
             clean_path = DOT + path_from_root[1:] if path_from_root.startswith("-") else path_from_root
-        tags = set(identify.tags_from_filename(clean_path))
+        tags = FileInfo.tags_from_filename(clean_path)
         return cls(project, clean_path, tags)
+
+    @staticmethod
+    def tags_from_filename(path: str) -> set[str]:
+        """Get a list of tags associated with the file."""
+        tags = identify.tags_from_filename(path)
+
+        # Check for conflicting tags, there can be only one of them
+        found_tags = CONFLICTING_TAGS.intersection(tags)
+        if len(found_tags) > 1 and (ext := Path(path).suffix):
+            # The file has a valid extension and not just some ".dotfile"
+            ext = ext[1:].lower()
+            logger.info(f"Found conflicting tags {found_tags} for file at {path}")
+            if ext in found_tags:
+                logger.info(f"Keeping '{ext}' tag as it matches the extension")
+                # Keep only the tag that matches the extension
+                tags -= found_tags
+                tags.add(ext)
+
+        # If there's no conflict or the extension is not recognized, return all the tags
+        return tags

--- a/src/nitpick/plugins/ini.py
+++ b/src/nitpick/plugins/ini.py
@@ -11,6 +11,7 @@ from configupdater import ConfigUpdater, Space
 
 from nitpick.plugins import hookimpl
 from nitpick.plugins.base import NitpickPlugin
+from nitpick.typedefs import JsonDict, mypy_property
 from nitpick.violations import Fuss, ViolationEnum
 
 if TYPE_CHECKING:
@@ -55,10 +56,15 @@ class IniPlugin(NitpickPlugin):
     updater: ConfigUpdater
     comma_separated_values: set[str]
 
+    @mypy_property
+    def comma_separated_values_dict(self) -> JsonDict:
+        """TOML dict of files which define which config entry is a list of comma separated values."""
+        return self.info.project.nitpick_files_section.get(COMMA_SEPARATED_VALUES, {})
+
     def post_init(self):
         """Post initialization after the instance was created."""
         self.updater = ConfigUpdater()
-        self.comma_separated_values = set(self.nitpick_file_dict.get(COMMA_SEPARATED_VALUES, []))
+        self.comma_separated_values = set(self.comma_separated_values_dict.get(self.filename, []))
 
         if not self.needs_top_section:
             return

--- a/src/nitpick/resources/python/flake8.toml
+++ b/src/nitpick/resources/python/flake8.toml
@@ -24,5 +24,5 @@ additional_dependencies = ["flake8-blind-except", "flake8-bugbear", "flake8-comp
 [".codeclimate.yml".plugins.pep8]  # https://docs.codeclimate.com/docs/pep8 PEP8 already being checked by flake8 plugins on pre-commit
 enabled = false
 
-[nitpick.files."setup.cfg"]
-comma_separated_values = ["flake8.ignore", "flake8.exclude"]
+[nitpick.files.comma_separated_values]
+"setup.cfg" = ["flake8.ignore", "flake8.exclude"]

--- a/src/nitpick/resources/python/isort.toml
+++ b/src/nitpick/resources/python/isort.toml
@@ -21,5 +21,5 @@ repo = "https://github.com/PyCQA/isort"
 [[".pre-commit-config.yaml".repos.hooks]]
 id = "isort"
 
-[nitpick.files."setup.cfg"]
-comma_separated_values = ["isort.skip", "isort.known_first_party"]
+[nitpick.files.comma_separated_values]
+"setup.cfg" = ["isort.skip", "isort.known_first_party"]

--- a/src/nitpick/schemas.py
+++ b/src/nitpick/schemas.py
@@ -8,7 +8,7 @@ from sortedcontainers import SortedDict
 
 from nitpick import fields
 from nitpick.blender import flatten_quotes
-from nitpick.constants import PYTHON_SETUP_CFG, READ_THE_DOCS_URL
+from nitpick.constants import READ_THE_DOCS_URL
 
 
 def flatten_marshmallow_errors(errors: dict) -> str:
@@ -46,25 +46,18 @@ class NitpickStylesSectionSchema(BaseNitpickSchema):
     include = PolyField(deserialization_schema_selector=fields.string_or_list_field)
 
 
-class IniSchema(BaseNitpickSchema):
-    """Validation schema for INI files."""
-
-    error_messages = {  # noqa: RUF012
-        "unknown": help_message("Unknown configuration", "nitpick_section.html#comma-separated-values")
-    }
-
-    comma_separated_values = fields.List(fields.String(validate=fields.validate_section_dot_field))
-
-
 class NitpickFilesSectionSchema(BaseNitpickSchema):
     """Validation schema for the ``[nitpick.files]`` section on the style file."""
 
-    error_messages = {"unknown": help_message("Unknown file", "nitpick_section.html#nitpick-files")}  # noqa: RUF012
+    error_messages = {  # noqa: RUF012
+        "unknown": help_message("Unknown configuration", "nitpick_section.html#nitpick-files")
+    }
 
     absent = fields.Dict(fields.NonEmptyString, fields.String())
     present = fields.Dict(fields.NonEmptyString, fields.String())
-    # TODO: refactor: load this schema dynamically, then add this next field setup_cfg
-    setup_cfg = fields.Nested(IniSchema, data_key=PYTHON_SETUP_CFG)
+    comma_separated_values = fields.Dict(
+        fields.NonEmptyString, fields.List(fields.String(validate=fields.validate_section_dot_field))
+    )
 
 
 class NitpickMetaSchema(BaseNitpickSchema):

--- a/tests/test_builtin/real.toml
+++ b/tests/test_builtin/real.toml
@@ -36,5 +36,5 @@ include = [
     "py://nitpick/resources/javascript/package-json",
 ]
 
-[nitpick.files."setup.cfg"]
-comma_separated_values = ["flake8.ignore", "flake8.exclude", "isort.skip", "isort.known_first_party"]
+[nitpick.files.comma_separated_values]
+"setup.cfg" = ["flake8.ignore", "flake8.exclude", "isort.skip", "isort.known_first_party"]

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -21,6 +21,7 @@ from nitpick.generic import (
     glob_non_ignored_files,
     relative_to_current_dir,
 )
+from nitpick.plugins import FileInfo
 
 
 @mock.patch.object(Path, "cwd")
@@ -73,14 +74,7 @@ def test_relative_to_current_dir(home, cwd):
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows-only test")
-@pytest.mark.parametrize(
-    "test_path",
-    [
-        "C:\\",
-        r"C:\path\file.toml",
-        r"//server/share/path/file.toml",
-    ],
-)
+@pytest.mark.parametrize("test_path", ["C:\\", r"C:\path\file.toml", r"//server/share/path/file.toml"])
 def test_url_to_windows_path(test_path):
     """Verify that Path to URL to Path conversion preserves the path."""
     path = WindowsPath(test_path)
@@ -89,14 +83,7 @@ def test_url_to_windows_path(test_path):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX-only test")
-@pytest.mark.parametrize(
-    "test_path",
-    [
-        "/",
-        "/path/to/file.toml",
-        "//double/slash/path.toml",
-    ],
-)
+@pytest.mark.parametrize("test_path", ["/", "/path/to/file.toml", "//double/slash/path.toml"])
 def test_url_to_posix_path(test_path):
     """Verify that Path to URL to Path conversion preserves the path."""
     path = PosixPath(test_path)
@@ -138,13 +125,9 @@ def test_glob_local_gitignore(some_directory: Path) -> None:
         some_directory / "README.md",
         some_directory / "src" / "module.py",
     }
-    assert set(glob_non_ignored_files(some_directory, "*.md")) == {
-        some_directory / "README.md",
-    }
+    assert set(glob_non_ignored_files(some_directory, "*.md")) == {some_directory / "README.md"}
     assert set(glob_non_ignored_files(some_directory, "*.txt")) == set()
-    assert set(glob_non_ignored_files(some_directory, "**/*.py")) == {
-        some_directory / "src" / "module.py",
-    }
+    assert set(glob_non_ignored_files(some_directory, "**/*.py")) == {some_directory / "src" / "module.py"}
 
 
 @pytest.mark.parametrize("some_directory", ["no_git_dir"], indirect=True)
@@ -177,14 +160,31 @@ def test_glob_global_gitignore(some_directory: Path) -> None:
     ],
 )
 @mock.patch("subprocess.check_output")
-def test_error_when_calling_git_config(
-    mock_check_output,
-    capsys,
-    exception: Exception,
-    message: str,
-) -> None:
+def test_error_when_calling_git_config(mock_check_output, capsys, exception: Exception, message: str) -> None:
     """Test error when calling git config."""
     mock_check_output.side_effect = exception
     assert get_global_gitignore_path() is None
     captured = capsys.readouterr()
     assert captured.err.strip().casefold() == message.strip().casefold()
+
+
+@pytest.mark.parametrize(
+    ("filepath", "expected_tags"),
+    [
+        ("foo/.pylintrc.toml", {"pylintrc", "text", "toml"}),
+        ("foo/pylintrc.toml", {"pylintrc", "text", "toml"}),
+        ("foo/.pylintrc", {"pylintrc", "text", "ini"}),
+        ("foo/pylintrc", {"pylintrc", "text", "ini"}),
+    ],
+)
+def test_different_types_of_pylintrc_config_should_work(filepath: str, expected_tags: set[str]):
+    """Different pylintrc configs should have different expected tags.
+
+    'pylintrc' is a special case where the config can either be a TOML or INI file.
+    Determining the correct tags is important for the plugins to work correctly.
+    Having an incorrect plugin working on a file can lead to unexpected results.
+
+    More on how pylint search for and use configuration files:
+    https://pylint.pycqa.org/en/latest/user_guide/usage/run.html#command-line-options
+    """
+    assert FileInfo.tags_from_filename(filepath) == expected_tags

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -496,3 +496,31 @@ def test_generic_ini_with_missing_header(tmp_path):
     ).assert_file_contents(
         "generic.ini", expected_generic_ini
     )
+
+
+def test_falsy_values_should_be_reported_and_fixed(tmp_path, datadir):
+    """Test that falsy and truthy values are included in the report."""
+    filename = "foo/file.ini"
+    project = ProjectMock(tmp_path).save_file(filename, datadir / "falsy_values/actual.ini")
+    project.style(datadir / "falsy_values/desired.toml").api_check_then_fix(
+        *[
+            Fuss(
+                True,
+                filename,
+                Violations.OPTION_HAS_DIFFERENT_VALUE.code,
+                f": [config]{name} is {actual} but it should be like this:",
+                f"[config]\n{name} = {expected}",
+            )
+            for (name, actual, expected) in [
+                ("boolean_true_unmatch", "false", "True"),
+                ("boolean_false_unmatch", "true", "False"),
+                ("string_a_unmatch", "string_b", "string_a"),
+                ("string_b_unmatch", "string_a", "string_b"),
+                ("truthy_int_unmatch", "0", "1"),
+                ("falsy_int_unmatch", "1", "0"),
+                ("truthy_float_unmatch", "0.0", "1.0"),
+                ("falsy_float_unmatch", "1.0", "0.0"),
+            ]
+        ]
+    ).assert_file_contents(filename, datadir / "falsy_values/expected.ini")
+    project.api_check().assert_violations()

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -6,7 +6,7 @@ from unittest import mock
 from configupdater import ConfigUpdater
 
 from nitpick.constants import EDITOR_CONFIG, PYTHON_SETUP_CFG
-from nitpick.plugins.ini import IniPlugin, Violations
+from nitpick.plugins.ini import COMMA_SEPARATED_VALUES, IniPlugin, Violations
 from nitpick.violations import Fuss, SharedViolations
 from tests.helpers import ProjectMock
 
@@ -20,8 +20,8 @@ def test_comma_separated_keys_on_style_file(tmp_path):
     """Comma separated keys on the style file."""
     ProjectMock(tmp_path).style(
         f"""
-        [nitpick.files."{PYTHON_SETUP_CFG}"]
-        comma_separated_values = ["food.eat", "food.drink"]
+        [nitpick.files.{COMMA_SEPARATED_VALUES}]
+        "{PYTHON_SETUP_CFG}" = ["food.eat", "food.drink"]
 
         ["{PYTHON_SETUP_CFG}".food]
         eat = "salt,ham,eggs"
@@ -301,9 +301,7 @@ def test_missing_different_values_editorconfig_with_root(tmp_path, datadir):
             another_missing = 100
             """,
         ),
-    ).assert_file_contents(
-        EDITOR_CONFIG, datadir / "2-expected-editorconfig.ini"
-    )
+    ).assert_file_contents(EDITOR_CONFIG, datadir / "2-expected-editorconfig.ini")
 
 
 def test_invalid_configuration_comma_separated_values(tmp_path):
@@ -316,8 +314,8 @@ def test_invalid_configuration_comma_separated_values(tmp_path):
         ignore = "D100,D101,D102,D103,D104,D105,D106,D107,D202,E203,W503"
         select = "E241,C,E,F,W,B,B9"
 
-        [nitpick.files."{PYTHON_SETUP_CFG}"]
-        comma_separated_values = ["flake8.ignore", "flake8.exclude"]
+        [nitpick.files.{COMMA_SEPARATED_VALUES}]
+        "{PYTHON_SETUP_CFG}" = ["flake8.ignore", "flake8.exclude"]
         """
     ).api_check().assert_violations(
         Fuss(
@@ -340,8 +338,8 @@ def test_invalid_section_dot_fields(tmp_path):
     """Test invalid section/field pairs."""
     ProjectMock(tmp_path).style(
         f"""
-        [nitpick.files."{PYTHON_SETUP_CFG}"]
-        comma_separated_values = ["no_dot", "multiple.dots.here", ".filed_only", "section_only."]
+        [nitpick.files.{COMMA_SEPARATED_VALUES}]
+        "{PYTHON_SETUP_CFG}" = ["no_dot", "multiple.dots.here", ".filed_only", "section_only."]
         """
     ).setup_cfg("").api_check().assert_violations(
         Fuss(
@@ -350,10 +348,10 @@ def test_invalid_section_dot_fields(tmp_path):
             1,
             " has an incorrect style. Invalid config:",
             f"""
-            nitpick.files."{PYTHON_SETUP_CFG}".comma_separated_values.0: Dot is missing. Use <section_name>.<field_name>
-            nitpick.files."{PYTHON_SETUP_CFG}".comma_separated_values.1: There's more than one dot. Use <section_name>.<field_name>
-            nitpick.files."{PYTHON_SETUP_CFG}".comma_separated_values.2: Empty section name. Use <section_name>.<field_name>
-            nitpick.files."{PYTHON_SETUP_CFG}".comma_separated_values.3: Empty field name. Use <section_name>.<field_name>
+            nitpick.files.{COMMA_SEPARATED_VALUES}."{PYTHON_SETUP_CFG}".value.0: Dot is missing. Use <section_name>.<field_name>
+            nitpick.files.{COMMA_SEPARATED_VALUES}."{PYTHON_SETUP_CFG}".value.1: There's more than one dot. Use <section_name>.<field_name>
+            nitpick.files.{COMMA_SEPARATED_VALUES}."{PYTHON_SETUP_CFG}".value.2: Empty section name. Use <section_name>.<field_name>
+            nitpick.files.{COMMA_SEPARATED_VALUES}."{PYTHON_SETUP_CFG}".value.3: Empty field name. Use <section_name>.<field_name>
             """,
         )
     )
@@ -368,8 +366,8 @@ def test_invalid_sections_comma_separated_values(tmp_path):
         exclude = "venv*,**/migrations/"
         per-file-ignores = "tests/**.py:FI18,setup.py:FI18"
 
-        [nitpick.files."{PYTHON_SETUP_CFG}"]
-        comma_separated_values = ["flake8.ignore", "flake8.exclude", "falek8.per-file-ignores", "aaa.invalid-section"]
+        [nitpick.files.{COMMA_SEPARATED_VALUES}]
+        "{PYTHON_SETUP_CFG}" = ["flake8.ignore", "flake8.exclude", "falek8.per-file-ignores", "aaa.invalid-section"]
         """
     ).setup_cfg(
         """
@@ -401,9 +399,7 @@ def test_multiline_comment(tmp_path, datadir):
             new = value
             """,
         )
-    ).assert_file_contents(
-        PYTHON_SETUP_CFG, datadir / "3-expected-setup.cfg"
-    )
+    ).assert_file_contents(PYTHON_SETUP_CFG, datadir / "3-expected-setup.cfg")
 
 
 def test_duplicated_option(tmp_path):
@@ -427,9 +423,7 @@ def test_duplicated_option(tmp_path):
             f": parsing error (DuplicateOptionError): While reading from {project.path_for(PYTHON_SETUP_CFG)!r} "
             f"[line  3]: option 'easy' in section 'abc' already exists",
         )
-    ).assert_file_contents(
-        PYTHON_SETUP_CFG, original_file
-    )
+    ).assert_file_contents(PYTHON_SETUP_CFG, original_file)
 
 
 @mock.patch.object(ConfigUpdater, "update_file")
@@ -463,9 +457,7 @@ def test_simulate_parsing_error_when_saving(update_file, tmp_path):
             Violations.PARSING_ERROR.code,
             ": parsing error (ParsingError): Source contains parsing errors: 'simulating a captured error'",
         ),
-    ).assert_file_contents(
-        PYTHON_SETUP_CFG, original_file
-    )
+    ).assert_file_contents(PYTHON_SETUP_CFG, original_file)
 
 
 def test_generic_ini_with_missing_header(tmp_path):
@@ -493,9 +485,7 @@ def test_generic_ini_with_missing_header(tmp_path):
             f"file: {project.path_for('generic.ini')!r}, line: 1\n"
             "'this_key_is_invalid = for a generic .ini (it should always have a section)\\n'",
         )
-    ).assert_file_contents(
-        "generic.ini", expected_generic_ini
-    )
+    ).assert_file_contents("generic.ini", expected_generic_ini)
 
 
 def test_falsy_values_should_be_reported_and_fixed(tmp_path, datadir):

--- a/tests/test_ini/falsy_values/actual.ini
+++ b/tests/test_ini/falsy_values/actual.ini
@@ -1,0 +1,17 @@
+[config]
+boolean_true_match = true
+boolean_true_unmatch = false
+boolean_false_match = false
+boolean_false_unmatch = true
+string_a_match = string_a
+string_a_unmatch = string_b
+string_b_match = string_b
+string_b_unmatch = string_a
+truthy_int_match = 1
+truthy_int_unmatch = 0
+falsy_int_match = 0
+falsy_int_unmatch = 1
+truthy_float_match = 1.0
+truthy_float_unmatch = 0.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 1.0

--- a/tests/test_ini/falsy_values/desired.toml
+++ b/tests/test_ini/falsy_values/desired.toml
@@ -1,0 +1,20 @@
+["foo/file.ini".config]
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+
+string_a_match = "string_a"
+string_a_unmatch = "string_a"
+string_b_match = "string_b"
+string_b_unmatch = "string_b"
+
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_ini/falsy_values/expected.ini
+++ b/tests/test_ini/falsy_values/expected.ini
@@ -1,0 +1,17 @@
+[config]
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+string_a_match = string_a
+string_a_unmatch = string_a
+string_b_match = string_b
+string_b_unmatch = string_b
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -68,7 +68,7 @@ def test_missing_message(tmp_path):
             "nitpick-style.toml",
             1,
             " has an incorrect style. Invalid config:",
-            f"""nitpick.files."pyproject.toml": Unknown file. See {READ_THE_DOCS_URL}nitpick_section.html#nitpick-files.""",
+            f"""nitpick.files."pyproject.toml": Unknown configuration. See {READ_THE_DOCS_URL}nitpick_section.html#nitpick-files.""",
         )
     )
 

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -55,9 +55,7 @@ def test_multiple_styles_overriding_values(offline, tmp_path):
         [tool.black]
         something = 22
         """
-    ).flake8(
-        offline=offline
-    ).assert_errors_contain(
+    ).flake8(offline=offline).assert_errors_contain(
         f"""
         NIP318 File pyproject.toml has missing values:{SUGGESTION_BEGIN}
         [tool.black]
@@ -136,9 +134,7 @@ def test_include_styles_overriding_values(offline, tmp_path):
         [tool.nitpick]
         style = "isort1"
         """
-    ).flake8(
-        offline=offline
-    ).assert_errors_contain(
+    ).flake8(offline=offline).assert_errors_contain(
         f"""
         NIP318 File pyproject.toml has missing values:{SUGGESTION_BEGIN}
         [tool.black]
@@ -185,9 +181,7 @@ def test_minimum_version(mocked_version, offline, tmp_path):
         [tool.black]
         line-length = 100
         """
-    ).flake8(
-        offline=offline
-    ).assert_single_error(
+    ).flake8(offline=offline).assert_single_error(
         "NIP203 The style file you're using requires nitpick>=1.0 (you have 0.5.3). Please upgrade"
     )
 
@@ -286,16 +280,12 @@ def test_symlink_subdir(offline, tmp_path):
         ["pyproject.toml".tool.black]
         line-length = 86
         """,
-    ).create_symlink(
-        "symlinked-style.toml", target_dir, "parent.toml"
-    ).pyproject_toml(
+    ).create_symlink("symlinked-style.toml", target_dir, "parent.toml").pyproject_toml(
         """
         [tool.nitpick]
         style = "symlinked-style"
         """
-    ).flake8(
-        offline=offline
-    ).assert_single_error(
+    ).flake8(offline=offline).assert_single_error(
         f"""
         NIP318 File pyproject.toml has missing values:{SUGGESTION_BEGIN}
         [tool.black]
@@ -666,9 +656,7 @@ def test_merge_styles_into_single_file(offline, tmp_path):
         [tool.nitpick]
         style = ["black", "isort", "isort_overrides"]
         """
-    ).flake8(
-        offline=offline
-    ).assert_merged_style(
+    ).flake8(offline=offline).assert_merged_style(
         f'''
         ["pyproject.toml".tool.black]
         line-length = 120
@@ -774,9 +762,7 @@ def test_invalid_nitpick_files(offline, tmp_path):
         [tool.nitpick]
         style = ["some_style", "wrong_files"]
         """
-    ).flake8(
-        offline=offline
-    ).assert_errors_contain(
+    ).flake8(offline=offline).assert_errors_contain(
         f"""
         NIP001 File some_style.toml has an incorrect style. Invalid config:{SUGGESTION_BEGIN}
         xxx: Unknown file. See {READ_THE_DOCS_URL}plugins.html.{SUGGESTION_END}
@@ -784,7 +770,7 @@ def test_invalid_nitpick_files(offline, tmp_path):
     ).assert_errors_contain(
         f"""
         NIP001 File wrong_files.toml has an incorrect style. Invalid config:{SUGGESTION_BEGIN}
-        nitpick.files.whatever: Unknown file. See {READ_THE_DOCS_URL}nitpick_section.html#nitpick-files.{SUGGESTION_END}
+        nitpick.files.whatever: Unknown configuration. See {READ_THE_DOCS_URL}nitpick_section.html#nitpick-files.{SUGGESTION_END}
         """,
         2,
     )
@@ -961,3 +947,45 @@ def test_protocol_not_supported(tmp_path):
     with pytest.raises(RuntimeError) as exc_info:
         project.api_check()
     assert str(exc_info.value) == "URL protocol 'abc' is not supported"
+
+
+def test_old_comma_separated_values_config_should_be_invalid(tmp_path):
+    """Invalid [nitpick.files] section."""
+    ProjectMock(tmp_path).named_style(
+        "some_style",
+        """
+        [nitpick.files.".flake8"]
+        comma_separated_values = [
+           "flake8.ignore",
+        ]
+        """,
+    ).pyproject_toml(
+        """
+        [tool.nitpick]
+        style = ["some_style"]
+        """
+    ).flake8().assert_errors_contain(
+        f"""
+        NIP001 File some_style.toml has an incorrect style. Invalid config:{SUGGESTION_BEGIN}
+        nitpick.files.".flake8": Unknown configuration. See {READ_THE_DOCS_URL}nitpick_section.html#nitpick-files.{SUGGESTION_END}
+        """,
+        1,
+    )
+
+
+def test_new_comma_separated_values_config_should_be_valid(tmp_path):
+    """Valid [nitpick.files] section."""
+    ProjectMock(tmp_path).named_style(
+        "some_style",
+        """
+        [nitpick.files.comma_separated_values]
+        ".flake8" = [
+           "flake8.ignore",
+        ]
+        """,
+    ).pyproject_toml(
+        """
+        [tool.nitpick]
+        style = ["some_style"]
+        """
+    ).flake8().assert_no_errors()

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -165,3 +165,28 @@ def test_missing_different_values_any_toml(tmp_path):
         list = ["a", "b", "c"]
         """,
     )
+
+
+def test_falsy_values_should_be_reported_and_fixed(tmp_path, datadir):
+    """Test that falsy and truthy values are included in the report."""
+    filename = "foo/file.toml"
+    project = ProjectMock(tmp_path).save_file(filename, datadir / "falsy_values/actual.toml")
+    project.style(datadir / "falsy_values/desired.toml").api_check_then_fix(
+        Fuss(
+            True,
+            filename,
+            319,
+            " has different values. Use this:",
+            """
+            boolean_true_unmatch = true
+            boolean_false_unmatch = false
+            string_a_unmatch = "string_a"
+            string_b_unmatch = "string_b"
+            truthy_int_unmatch = 1
+            falsy_int_unmatch = 0
+            truthy_float_unmatch = 1.0
+            falsy_float_unmatch = 0.0
+            """,
+        )
+    ).assert_file_contents(filename, datadir / "falsy_values/expected.toml")
+    project.api_check().assert_violations()

--- a/tests/test_toml/falsy_values/actual.toml
+++ b/tests/test_toml/falsy_values/actual.toml
@@ -1,0 +1,16 @@
+boolean_true_match = true
+boolean_true_unmatch = false
+boolean_false_match = false
+boolean_false_unmatch = true
+string_a_match = "string_a"
+string_a_unmatch = "string_b"
+string_b_match = "string_b"
+string_b_unmatch = "string_a"
+truthy_int_match = 1
+truthy_int_unmatch = 0
+falsy_int_match = 0
+falsy_int_unmatch = 1
+truthy_float_match = 1.0
+truthy_float_unmatch = 0.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 1.0

--- a/tests/test_toml/falsy_values/desired.toml
+++ b/tests/test_toml/falsy_values/desired.toml
@@ -1,0 +1,20 @@
+["foo/file.toml"]
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+
+string_a_match = "string_a"
+string_a_unmatch = "string_a"
+string_b_match = "string_b"
+string_b_unmatch = "string_b"
+
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_toml/falsy_values/expected.toml
+++ b/tests/test_toml/falsy_values/expected.toml
@@ -1,0 +1,16 @@
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+string_a_match = "string_a"
+string_a_unmatch = "string_a"
+string_b_match = "string_b"
+string_b_unmatch = "string_b"
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -156,3 +156,28 @@ def test_maximum_two_level_nesting_on_lists_using_jmes_expression_as_list_key_fa
         ),
     ).assert_file_contents(filename, datadir / "jmes-list-key-expected.yaml")
     project.api_check().assert_violations()
+
+
+def test_falsy_values_should_be_reported_and_fixed(tmp_path, datadir):
+    """Test that falsy and truthy values are included in the report."""
+    filename = "foo/file.yaml"
+    project = ProjectMock(tmp_path).save_file(filename, datadir / "falsy_values/actual.yaml")
+    project.style(datadir / "falsy_values/desired.toml").api_check_then_fix(
+        Fuss(
+            True,
+            filename,
+            369,
+            " has different values. Use this:",
+            """
+            boolean_true_unmatch: true
+            boolean_false_unmatch: false
+            string_a_unmatch: string_a
+            string_b_unmatch: string_b
+            truthy_int_unmatch: 1
+            falsy_int_unmatch: 0
+            truthy_float_unmatch: 1.0
+            falsy_float_unmatch: 0.0
+            """,
+        )
+    ).assert_file_contents(filename, datadir / "falsy_values/expected.yaml")
+    project.api_check().assert_violations()

--- a/tests/test_yaml/falsy_values/actual.yaml
+++ b/tests/test_yaml/falsy_values/actual.yaml
@@ -1,0 +1,16 @@
+boolean_true_match: true
+boolean_true_unmatch: false
+boolean_false_match: false
+boolean_false_unmatch: true
+string_a_match: "string_a"
+string_a_unmatch: "string_b"
+string_b_match: "string_b"
+string_b_unmatch: "string_a"
+truthy_int_match: 1
+truthy_int_unmatch: 0
+falsy_int_match: 0
+falsy_int_unmatch: 1
+truthy_float_match: 1.0
+truthy_float_unmatch: 0.0
+falsy_float_match: 0.0
+falsy_float_unmatch: 1.0

--- a/tests/test_yaml/falsy_values/desired.toml
+++ b/tests/test_yaml/falsy_values/desired.toml
@@ -1,0 +1,20 @@
+["foo/file.yaml"]
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+
+string_a_match = "string_a"
+string_a_unmatch = "string_a"
+string_b_match = "string_b"
+string_b_unmatch = "string_b"
+
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_yaml/falsy_values/expected.yaml
+++ b/tests/test_yaml/falsy_values/expected.yaml
@@ -1,0 +1,16 @@
+boolean_true_match: true
+boolean_true_unmatch: true
+boolean_false_match: false
+boolean_false_unmatch: false
+string_a_match: "string_a"
+string_a_unmatch: "string_a"
+string_b_match: "string_b"
+string_b_unmatch: "string_b"
+truthy_int_match: 1
+truthy_int_unmatch: 1
+falsy_int_match: 0
+falsy_int_unmatch: 0
+truthy_float_match: 1.0
+truthy_float_unmatch: 1.0
+falsy_float_match: 0.0
+falsy_float_unmatch: 0.0


### PR DESCRIPTION
Issues fixed by this pull request:

- Fix #25 

## Proposed changes

1. Handle Toml quotes properly

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [ ] ~CLI~
  - [ ] ~`flake8` plugin (normal mode)~
  - [ ] ~`flake8` plugin (offline mode)~
- [ ] ~Write documentation when there's a new API or functionality~

## Summary by Sourcery

Refactor the handling of TOML configuration files to support quoted section names. Update tests to reflect these changes and add new tests for falsy values.

Bug Fixes:
- Fix an issue where TOML sections with quoted names were not handled correctly.

Tests:
- Add tests for falsy value handling in TOML, YAML, and INI files.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?

Refactor the handling of TOML files to support sections with quoted names for specifying comma-separated values.

### Why are these changes being made?

These changes address an issue with specifying multiple values in the configuration for TOML files where section names need to be quoted. The added logic ensures that configurations such as flake8 ignore lists are correctly parsed and handled, thereby improving compatibility and flexibility for configurations in style files.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->