### PR TITLE
fix: Handling of TOML section with quoted name

### DIFF
--- a/src/nitpick/blender.py
+++ b/src/nitpick/blender.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import abc
 import json
 import re
-import shlex
 from collections.abc import Iterable
 from functools import partial
 from pathlib import Path
@@ -230,10 +229,7 @@ def quote_reducer(separator: str) -> Callable:
 
 def quotes_splitter(flat_key: str) -> tuple[str, ...]:
     """Split keys keeping quoted strings together."""
-    return tuple(
-        piece.replace(SEPARATOR_SPACE, SEPARATOR_DOT) if SEPARATOR_SPACE in piece else piece
-        for piece in shlex.split(flat_key.replace(SEPARATOR_DOT, SEPARATOR_SPACE))
-    )
+    return tuple(quoted_split(flat_key))
 
 
 def custom_reducer(separator: str) -> Callable:

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -190,3 +190,94 @@ def test_falsy_values_should_be_reported_and_fixed(tmp_path, datadir):
         )
     ).assert_file_contents(filename, datadir / "falsy_values/expected.toml")
     project.api_check().assert_violations()
+
+
+def test_missing_quoted_section_should_be_reported_and_fixed(tmp_path):
+    """Test that a missing quoted section are reported and added as a fix."""
+    filename = "foo/file.toml"
+    project = ProjectMock(tmp_path).save_file(
+        filename,
+        """
+        [existing_section]
+        key = "value"
+        """,
+    )
+    project.style(
+        """
+        ["foo/file.toml"."quoted section"]
+        key = "value"
+
+        ["foo/file.toml"."quoted section".nested]
+        key = "value"
+        """
+    ).api_check_then_fix(
+        Fuss(
+            True,
+            filename,
+            318,
+            " has missing values:",
+            '["quoted section"]\nkey = "value"\n\n["quoted section".nested]\nkey = "value"',
+        ),
+    ).assert_file_contents(
+        filename,
+        """
+        [existing_section]
+        key = "value"
+
+        ["quoted section"]
+        key = "value"
+
+        ["quoted section".nested]
+        key = "value"
+        """,
+    )
+
+
+def test_modify_quoted_section_value_should_be_reported_and_fixed(tmp_path):
+    """Test that modifying a value in a quoted section name works correctly."""
+    filename = "foo/file.toml"
+    project = ProjectMock(tmp_path).save_file(
+        filename,
+        """
+        [existing_section]
+        key = "value"
+
+        ["quoted section"]
+        key = "value"
+
+        ["quoted section".nested]
+        key = "value"
+        """,
+    )
+    project.style(
+        """
+        ["foo/file.toml"."quoted section"]
+        key = "value_to_modify"
+
+        ["foo/file.toml"."quoted section".nested]
+        key = "value_to_modify"
+        """
+    ).api_check_then_fix(
+        Fuss(
+            True,
+            filename,
+            319,
+            " has different values. Use this:",
+            '["quoted section"]\n'
+            'key = "value_to_modify"\n\n'
+            '["quoted section".nested]\n'
+            'key = "value_to_modify"',
+        )
+    ).assert_file_contents(
+        filename,
+        """
+        [existing_section]
+        key = "value"
+
+        ["quoted section"]
+        key = "value_to_modify"
+
+        ["quoted section".nested]
+        key = "value_to_modify"
+        """,
+    )

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -47,9 +47,7 @@ def test_suggest_initial_contents(tmp_path):
             " was not found. Create it with this content:",
             expected_toml,
         )
-    ).assert_file_contents(
-        filename, expected_toml
-    )
+    ).assert_file_contents(filename, expected_toml)
 
 
 def test_missing_different_values_pyproject_toml(tmp_path):
@@ -217,7 +215,7 @@ def test_missing_quoted_section_should_be_reported_and_fixed(tmp_path):
             318,
             " has missing values:",
             '["quoted section"]\nkey = "value"\n\n["quoted section".nested]\nkey = "value"',
-        ),
+        )
     ).assert_file_contents(
         filename,
         """


### PR DESCRIPTION
Issues fixed by this pull request:

- Fix #25 

## Proposed changes

1. Handle Toml quotes properly

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [ ] ~CLI~
  - [ ] ~`flake8` plugin (normal mode)~
  - [ ] ~`flake8` plugin (offline mode)~
- [ ] ~Write documentation when there's a new API or functionality~

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?
Remove `shlex.split` for parsing and split keys using a custom `quoted_split` method instead to handle TOML sections with quoted names; add unit tests for missing and modified quoted sections in TOML files.

### Why are these changes being made?
The change aims to address an issue with handling TOML sections having quoted names which were not properly handled by `shlex.split`. The custom `quoted_split` implementation provides more accurate splitting by considering quoted sections, improving the reliability and correctness of the configuration parsing, and new tests ensure this behavior is validated.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced key parsing to correctly preserve quoted segments, ensuring accurate handling of keys with spaces or dots.
  
- **Tests**
  - Added new validations that automatically detect and suggest corrections for missing or modified quoted sections in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->