### PR TITLE
feat: Support explicit file tags

### DIFF
--- a/docs/nitpick_section.rst
+++ b/docs/nitpick_section.rst
@@ -47,6 +47,16 @@ To enforce that certain files should not exist in the project, you can add them 
 Multiple files can be configured as above.
 The message is optional.
 
+Files that are unknown
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Files that don't have a valid extension nor recognized by ``identity`` lib can end up causing unknown file error in ``nitpick``. In such cases, you can explicitly declare the plugins (tags) to use for such files.
+
+.. code-block:: toml
+
+    [nitpick.files.tags]
+    ".shellcheckrc" = ["ini"]
+
 Comma separated values
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/nitpick/core.py
+++ b/src/nitpick/core.py
@@ -147,7 +147,8 @@ class Nitpick:
             logger.debug(f"{config_key}: Finding plugins to enforce style")
 
             # 2.
-            info = FileInfo.create(self.project, config_key)
+            tags = self.project.nitpick_files_section.get("tags", {}).get(config_key, [])
+            info = FileInfo.create(self.project, config_key, tags)
             # pylint: disable=no-member
             for plugin_class in self.project.plugin_manager.hook.can_handle(info=info):
                 yield from plugin_class(info, config_dict, autofix).entry_point()

--- a/src/nitpick/core.py
+++ b/src/nitpick/core.py
@@ -42,11 +42,7 @@ from nitpick.exceptions import QuitComplainingError
 from nitpick.generic import filter_names, glob_files, glob_non_ignored_files, relative_to_current_dir
 from nitpick.plugins.info import FileInfo
 from nitpick.schemas import BaseNitpickSchema, flatten_marshmallow_errors, help_message
-from nitpick.style import (
-    BuiltinStyle,
-    StyleManager,
-    builtin_styles,
-)
+from nitpick.style import BuiltinStyle, StyleManager, builtin_styles
 from nitpick.violations import Fuss, ProjectViolations, Reporter, StyleViolations
 
 if TYPE_CHECKING:

--- a/src/nitpick/plugins/info.py
+++ b/src/nitpick/plugins/info.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 from identify import identify
 from loguru import logger
@@ -27,21 +27,27 @@ class FileInfo:
     tags: set[str] = field(default_factory=set)
 
     @classmethod
-    def create(cls, project: Project, path_from_root: str) -> FileInfo:
+    def create(cls, project: Project, path_from_root: str, tags: Iterable[str] | None = None) -> FileInfo:
         """Clean the file name and get its tags."""
         if Deprecation.pre_commit_without_dash(path_from_root):
             clean_path = DOT + path_from_root
         else:
             clean_path = DOT + path_from_root[1:] if path_from_root.startswith("-") else path_from_root
-        tags = FileInfo.tags_from_filename(clean_path)
+
+        if not tags:
+            # Auto-detect a list of tags associated with the file
+            tags = identify.tags_from_filename(clean_path)
+
+        tags = FileInfo.remove_conflicting_tags(clean_path, tags)
         return cls(project, clean_path, tags)
 
     @staticmethod
-    def tags_from_filename(path: str) -> set[str]:
-        """Get a list of tags associated with the file."""
-        tags = identify.tags_from_filename(path)
+    def remove_conflicting_tags(path: str, input_tags: Iterable[str] | None) -> set[str]:
+        """Check and remove conflicting tags, there can be only one of them."""
+        if not input_tags:
+            return set()
 
-        # Check for conflicting tags, there can be only one of them
+        tags = set(input_tags)
         found_tags = CONFLICTING_TAGS.intersection(tags)
         if len(found_tags) > 1 and (ext := Path(path).suffix):
             # The file has a valid extension and not just some ".dotfile"

--- a/src/nitpick/schemas.py
+++ b/src/nitpick/schemas.py
@@ -55,6 +55,7 @@ class NitpickFilesSectionSchema(BaseNitpickSchema):
 
     absent = fields.Dict(fields.NonEmptyString, fields.String())
     present = fields.Dict(fields.NonEmptyString, fields.String())
+    tags = fields.Dict(fields.NonEmptyString, fields.List(fields.String()))
     comma_separated_values = fields.Dict(
         fields.NonEmptyString, fields.List(fields.String(validate=fields.validate_section_dot_field))
     )

--- a/src/nitpick/style.py
+++ b/src/nitpick/style.py
@@ -804,10 +804,7 @@ class BuiltinStyle:  # pylint: disable=too-few-public-methods
         if library_dir:
             # Style in a directory
             from_resources_root = without_suffix.relative_to(library_dir)
-            bis = BuiltinStyle(
-                formatted=str(without_suffix),
-                path_from_resources_root=from_resources_root.as_posix(),
-            )
+            bis = BuiltinStyle(formatted=str(without_suffix), path_from_resources_root=from_resources_root.as_posix())
         else:
             # Style from the built-in library
             package_path = resource_path.relative_to(builtin_resources_root().parent.parent)

--- a/src/nitpick/style.py
+++ b/src/nitpick/style.py
@@ -346,7 +346,8 @@ class ConfigValidator:
         validation_errors = {}
         toml_dict = {}
         for key, value_dict in config_dict.items():
-            info = FileInfo.create(self.project, key)
+            tags = toml_dict.get("nitpick", {}).get("files", {}).get("tags", {}).get(key, [])
+            info = FileInfo.create(self.project, key, tags)
             toml_dict[info.path_from_root] = value_dict
             validation_errors.update(self._validate_item(key, info, value_dict))
         return toml_dict, validation_errors

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -11,6 +11,8 @@ from unittest import mock
 
 import pytest
 from furl import furl
+from src.nitpick.plugins.ini import Violations
+from src.nitpick.violations import Fuss
 from testfixtures import compare
 
 from nitpick.constants import EDITOR_CONFIG, GIT_DIR, GIT_IGNORE, PYTHON_TOX_INI
@@ -22,6 +24,7 @@ from nitpick.generic import (
     relative_to_current_dir,
 )
 from nitpick.plugins import FileInfo
+from tests.helpers import ProjectMock
 
 
 @mock.patch.object(Path, "cwd")
@@ -177,7 +180,7 @@ def test_error_when_calling_git_config(mock_check_output, capsys, exception: Exc
         ("foo/pylintrc", {"pylintrc", "text", "ini"}),
     ],
 )
-def test_different_types_of_pylintrc_config_should_work(filepath: str, expected_tags: set[str]):
+def test_different_types_of_pylintrc_config_should_work(filepath: str, expected_tags: set[str], tmp_path: Path):
     """Different pylintrc configs should have different expected tags.
 
     'pylintrc' is a special case where the config can either be a TOML or INI file.
@@ -187,4 +190,65 @@ def test_different_types_of_pylintrc_config_should_work(filepath: str, expected_
     More on how pylint search for and use configuration files:
     https://pylint.pycqa.org/en/latest/user_guide/usage/run.html#command-line-options
     """
-    assert FileInfo.tags_from_filename(filepath) == expected_tags
+    project = ProjectMock(tmp_path)
+    info = FileInfo.create(project, filepath)
+    assert info.tags == expected_tags
+
+
+def test_unknown_file_should_raise_unknown_file_error(tmp_path):
+    """Test a file with unknown extension and name, which should cause unknown file error."""
+    filepath = "conf/.shellcheckrc"
+    ProjectMock(tmp_path).save_file(
+        filepath,
+        """
+        ; empty ini file, nothing but a comment
+        """,
+    ).style(
+        f"""
+        ["{filepath}".conf]
+        enable = "all"
+        """
+    ).api_check_then_fix(
+        Fuss(
+            fixed=False,
+            filename="nitpick-style.toml",
+            code=1,
+            message=" has an incorrect style. Invalid config:",
+            suggestion="conf/.shellcheckrc: Unknown file. See https://nitpick.rtfd.io/en/latest/plugins.html.",
+        )
+    )
+
+
+def test_explicit_files_tags_can_be_used_to_handle_unknown_file(tmp_path):
+    """Test explicit files tags can be used to handle unknown file whose extension and name are not recognized."""
+    filepath = "conf/.shellcheckrc"
+    ProjectMock(tmp_path).save_file(
+        filepath,
+        """
+        ; empty ini file, nothing but a comment
+        """,
+    ).style(
+        f"""
+        [nitpick.files.tags]
+        "{filepath}" = ["ini"]
+
+        ["{filepath}".conf]
+        enable = "all"
+        """
+    ).api_check_then_fix(
+        Fuss(
+            fixed=True,
+            filename=filepath,
+            code=Violations.MISSING_SECTIONS.code,
+            message=" has some missing sections. Use this:",
+            suggestion="[conf]\nenable = all",
+        )
+    ).assert_file_contents(
+        filepath,
+        """
+        ; empty ini file, nothing but a comment
+
+        [conf]
+        enable = all
+        """,
+    )


### PR DESCRIPTION
Issues fixed by this pull request:

- Fix #29 

## Proposed changes

1. Implement support to explicitly state what type of plugin to use for a file

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [ ] ~CLI~
  - [ ] ~`flake8` plugin (normal mode)~
  - [ ] ~`flake8` plugin (offline mode)~
- [x] ~Write documentation when there's a new API or functionality~

## Summary by Sourcery

New Features:
- Allow users to explicitly define file types in the nitpick configuration, enabling support for previously unrecognized files.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add support for explicit file tags in the `nitpick` library, enabling users to specify plugins for files with unknown extensions.

### Why are these changes being made?
Files with unknown extensions or unrecognized by the `identity` library could previously cause errors in `nitpick`. Allowing users to explicitly declare the plugins (tags) for these files provides a more flexible and error-free file handling approach. This update enhances compatibility and customization for different project setups.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new section that provides guidance on managing files with unrecognized extensions using explicit tag configuration.

- **New Features**
  - Enhanced file configuration now supports both manual and automatic tag assignments, improving accuracy and error reporting for unknown file types.

- **Tests**
  - Expanded tests verify that unknown files and explicit tag usage function as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->