### PR TITLE
feat: Make project option available globally

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -93,8 +93,9 @@ At the end of execution, this command displays:
       You can use partial and multiple file names in the FILES argument.
 
     Options:
-      -v, --verbose  Increase logging verbosity (-v = INFO, -vv = DEBUG)
-      --help         Show this message and exit.
+      -p, --project DIRECTORY  Path to project root
+      -v, --verbose            Increase logging verbosity (-v = INFO, -vv = DEBUG)
+      --help                   Show this message and exit.
 
 .. _cli_cmd_check:
 
@@ -113,8 +114,9 @@ At the end of execution, this command displays:
       argument.
 
     Options:
-      -v, --verbose  Increase logging verbosity (-v = INFO, -vv = DEBUG)
-      --help         Show this message and exit.
+      -p, --project DIRECTORY  Path to project root
+      -v, --verbose            Increase logging verbosity (-v = INFO, -vv = DEBUG)
+      --help                   Show this message and exit.
 
 .. _cli_cmd_ls:
 
@@ -132,7 +134,8 @@ At the end of execution, this command displays:
       and multiple file names in the FILES argument.
 
     Options:
-      --help  Show this message and exit.
+      -p, --project DIRECTORY  Path to project root
+      --help                   Show this message and exit.
 
 .. _cli_cmd_init:
 
@@ -147,6 +150,7 @@ At the end of execution, this command displays:
       Create or update the [tool.nitpick] table in the configuration file.
 
     Options:
+      -p, --project DIRECTORY  Path to project root
       -f, --fix                Autofix the files changed by the command;
                                otherwise, just print what would be done
       -s, --suggest            Suggest styles based on the extension of project

--- a/src/nitpick/cli.py
+++ b/src/nitpick/cli.py
@@ -180,7 +180,7 @@ def ls(context, project: Path | None, files):  # pylint: disable=invalid-name
     help="Library dir to scan for style files (implies --suggest); if not provided, uses the built-in style library",
 )
 @click.argument("style_urls", nargs=-1)
-def init(  # noqa: PLR0913
+def init(  # noqa: PLR0913, pylint: disable=too-many-arguments
     context,
     project: Path | None,
     fix: bool,  # pylint: disable=redefined-outer-name

--- a/src/nitpick/cli.py
+++ b/src/nitpick/cli.py
@@ -42,15 +42,17 @@ VERBOSE_OPTION = click.option(
     "--verbose", "-v", count=True, default=False, help="Increase logging verbosity (-v = INFO, -vv = DEBUG)"
 )
 FILES_ARGUMENT = click.argument("files", nargs=-1)
-
-
-@click.group()
-@click.option(
+# TODO(phuongfi91): Project option is made available globally in an ugly way. Refactor it.
+PROJECT_OPTION = click.option(
     "--project",
     "-p",
     type=click.Path(exists=True, dir_okay=True, file_okay=False, resolve_path=True),
     help="Path to project root",
 )
+
+
+@click.group()
+@PROJECT_OPTION
 @click.option(
     f"--{Flake8OptionEnum.OFFLINE.name.lower()}",  # pylint: disable=no-member
     is_flag=True,
@@ -62,18 +64,19 @@ def nitpick_cli(project: Path | None = None, offline=False):  # pylint: disable=
     """Enforce the same settings across multiple language-independent projects."""
 
 
-def get_nitpick(context: click.Context) -> Nitpick:
+def get_nitpick(context: click.Context, project: Path | None = None) -> Nitpick:
     """Create a Nitpick instance from the click context parameters."""
-    project = None
     offline = False
     if context.parent:
-        project = context.parent.params["project"]
+        project = (
+            project or context.parent.params["project"]
+        )  # prioritize 'project' from the current command over the one from context
         offline = context.parent.params["offline"]
     project_root: Path | None = Path(project) if project else None
     return Nitpick.singleton().init(project_root, offline)
 
 
-def common_fix_or_check(context, verbose: int, files, check_only: bool) -> None:
+def common_fix_or_check(context, project: Path | None, verbose: int, files, check_only: bool) -> None:
     """Common CLI code for both "fix" and "check" commands."""
     if verbose:
         level = logging.INFO if verbose == 1 else logging.DEBUG
@@ -85,7 +88,7 @@ def common_fix_or_check(context, verbose: int, files, check_only: bool) -> None:
 
         logger.enable(PROJECT_NAME)
 
-    nit = get_nitpick(context)
+    nit = get_nitpick(context, project)
     try:
         for fuss in nit.run(*files, autofix=not check_only):
             nit.echo(fuss.pretty)
@@ -101,39 +104,42 @@ def common_fix_or_check(context, verbose: int, files, check_only: bool) -> None:
 
 @nitpick_cli.command()
 @click.pass_context
+@PROJECT_OPTION
 @VERBOSE_OPTION
 @FILES_ARGUMENT
-def fix(context, verbose, files):
+def fix(context, project: Path | None, verbose, files):
     """Fix files, modifying them directly.
 
     You can use partial and multiple file names in the FILES argument.
     """
-    common_fix_or_check(context, verbose, files, False)
+    common_fix_or_check(context, project, verbose, files, False)
 
 
 @nitpick_cli.command()
 @click.pass_context
+@PROJECT_OPTION
 @VERBOSE_OPTION
 @FILES_ARGUMENT
-def check(context, verbose, files):
+def check(context, project: Path | None, verbose, files):
     """Don't modify files, just print the differences.
 
     Return code 0 means nothing would change. Return code 1 means some files would be modified.
     You can use partial and multiple file names in the FILES argument.
     """
-    common_fix_or_check(context, verbose, files, True)
+    common_fix_or_check(context, project, verbose, files, True)
 
 
 @nitpick_cli.command()
 @click.pass_context
+@PROJECT_OPTION
 @FILES_ARGUMENT
-def ls(context, files):  # pylint: disable=invalid-name
+def ls(context, project: Path | None, files):  # pylint: disable=invalid-name
     """List of files configured in the Nitpick style.
 
     Display existing files in green and absent files in red.
     You can use partial and multiple file names in the FILES argument.
     """
-    nit = get_nitpick(context)
+    nit = get_nitpick(context, project)
     try:
         violations = list(nit.project.merge_styles(nit.offline))
         error_exit_code = 1
@@ -152,6 +158,7 @@ def ls(context, files):  # pylint: disable=invalid-name
 
 @nitpick_cli.command()
 @click.pass_context
+@PROJECT_OPTION
 @click.option(
     "--fix",
     "-f",
@@ -173,8 +180,9 @@ def ls(context, files):  # pylint: disable=invalid-name
     help="Library dir to scan for style files (implies --suggest); if not provided, uses the built-in style library",
 )
 @click.argument("style_urls", nargs=-1)
-def init(
+def init(  # noqa: PLR0913
     context,
+    project: Path | None,
     fix: bool,  # pylint: disable=redefined-outer-name
     suggest: bool,
     library: str | None,
@@ -194,7 +202,7 @@ def init(
         )
         return
 
-    nit = get_nitpick(context)
+    nit = get_nitpick(context, project)
     config = nit.project.read_configuration()
 
     # Convert tuple to list, so we can add styles to it


### PR DESCRIPTION
Issues fixed by this pull request:

- Fix #36

## Proposed changes

1. Make `--project` option available everywhere
2. The solution isn't ideal (kinda hacky) so we better go back to refactoring it someday

## Summary by Sourcery

Make the project option available globally. This change allows users to specify the project path once and have it apply to all commands, rather than having to specify it repeatedly.

New Features:
- Make the `--project` option available globally to all commands

Bug Fixes:
- Fix incorrect handling of the project option when not set

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Make the project option globally available for all CLI commands by introducing a `PROJECT_OPTION` with the `-p` or `--project` argument, allowing the specification of a project root path.

### Why are these changes being made?

This change aims to improve user experience by standardizing the way to set project roots across different CLI commands. Previously, users would have to specify the project root individually for each command. With this update, the same option is globally accessible, simplifying the workflow. However, there is a noted need for refactoring as the current implementation might be suboptimal.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new project directory option to several CLI commands (fix, check, ls, and init) to allow users to specify the project root.
- **Documentation**
	- Updated the command-line interface documentation to reflect the inclusion of the project directory option for enhanced command usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->